### PR TITLE
Update external.desc

### DIFF
--- a/external.desc
+++ b/external.desc
@@ -1,2 +1,2 @@
 name: SIRSIPE_EXTERNALS
-desc: Simo Erkinheimo's configs and packages
+desc: Simo Erkinheimos configs and packages


### PR DESCRIPTION
This apostrophe breaks the command 
```make BR2_EXTERNAL=../buildroot-externals list-defconfigs``` 
causing the following error:
```
/bin/bash: -c: line 1: unexpected EOF while looking for matching `"'
```